### PR TITLE
adding BQ Aquaris U lite

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ List of Android phones/devices that support the live capture of BLE packets to W
 Phones:
 
 1. LG-M150 -- "LG Phoenix 3"
+2. BQ Aquaris U lite. Android version: 7.1.1


### PR DESCRIPTION
Hi @freqyXin,

I just found that the BQ Aquaris U lite Android device supports capture live BLE packets (BTsnoop) with Wireshark via adb. And wanted to share it, luckily I found your list.

I took this Wireshark screenshot as some kind of proof.
![wireshark showing that "BQ Aquaris U lite" Android device could do live captures of BLE packets abd BTsnoop](https://cdn.some.pics/char/65084a23ab97a.png)
